### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/KittyCAD/ruleset-policy-bot/security/code-scanning/2](https://github.com/KittyCAD/ruleset-policy-bot/security/code-scanning/2)

In general, the fix is to explicitly declare `permissions` for the `GITHUB_TOKEN` in the workflow, either at the root level (applies to all jobs) or per job. Since this workflow currently has just one job (`build`) that only needs to read repository contents to check out the code, the least-privilege configuration is to set `contents: read`. This both satisfies CodeQL and adheres to GitHub’s recommended baseline.

The single best fix without changing functionality is to add a `permissions` block under the `build` job (or alternatively at the root level) granting only read access to repository contents. Concretely, in `.github/workflows/build.yml`, insert:

```yml
    permissions:
      contents: read
```

right after `runs-on: ubuntu-latest` (line 11). No other steps need write access, and `actions/checkout` works with `contents: read`. No imports or external tools are required; it’s a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
